### PR TITLE
Pixel buffer object capturer

### DIFF
--- a/src/main/java/info/ata4/minecraft/minema/client/capture/ACapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/ACapturer.java
@@ -9,10 +9,12 @@ import java.nio.ByteBuffer;
 import org.lwjgl.util.Dimension;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.OpenGlHelper;
 
 public abstract class ACapturer {
 
 	protected static final Minecraft MC = Minecraft.getMinecraft();
+	protected static final boolean isFramebufferEnabled = OpenGlHelper.isFramebufferEnabled();
 	protected static final int bytesPerPixel = 3;
 	protected static final int TYPE = GL_UNSIGNED_BYTE;
 

--- a/src/main/java/info/ata4/minecraft/minema/client/capture/ACapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/ACapturer.java
@@ -24,7 +24,9 @@ public abstract class ACapturer {
 
 	private byte[] flipLine1 = null;
 	private byte[] flipLine2 = null;
-	protected int colorFormat = GL_RGB;
+	// BGR is the internal OpenGL format -> try to use that as
+	// frequently as possible
+	protected int colorFormat = GL_BGR;
 
 	public ACapturer() {
 		this.start = new Dimension(MC.displayWidth, MC.displayHeight);
@@ -59,15 +61,6 @@ public abstract class ACapturer {
 		}
 	}
 
-	public final void setFlipColors() {
-		colorFormat = GL_BGR;
-	}
-
-	public final void setFlipLines() {
-		flipLine1 = new byte[start.getWidth() * bytesPerPixel];
-		flipLine2 = new byte[start.getWidth() * bytesPerPixel];
-	}
-
 	public final ByteBuffer getByteBuffer() {
 		prepareByteBuffer();
 		// Rewinding to pos 0 (after capture)
@@ -97,6 +90,15 @@ public abstract class ACapturer {
 
 	public final Dimension getCaptureDimension() {
 		return this.start;
+	}
+
+	public final void setFlipLines() {
+		flipLine1 = new byte[start.getWidth() * bytesPerPixel];
+		flipLine2 = new byte[start.getWidth() * bytesPerPixel];
+	}
+
+	public final void setToRGBMode() {
+		colorFormat = GL_RGB;
 	}
 
 	protected abstract void capture();

--- a/src/main/java/info/ata4/minecraft/minema/client/capture/ACapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/ACapturer.java
@@ -1,0 +1,104 @@
+package info.ata4.minecraft.minema.client.capture;
+
+import static org.lwjgl.opengl.GL11.GL_RGB;
+import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
+import static org.lwjgl.opengl.GL12.GL_BGR;
+
+import java.nio.ByteBuffer;
+
+import org.lwjgl.util.Dimension;
+
+import net.minecraft.client.Minecraft;
+
+public abstract class ACapturer {
+
+	protected static final Minecraft MC = Minecraft.getMinecraft();
+	protected static final int bytesPerPixel = 3;
+	protected static final int TYPE = GL_UNSIGNED_BYTE;
+
+	protected final Dimension start;
+	protected final int bufferSize;
+	protected final ByteBuffer buffer;
+
+	private byte[] flipLine1 = null;
+	private byte[] flipLine2 = null;
+	protected int colorFormat = GL_RGB;
+
+	public ACapturer() {
+		this.start = new Dimension(MC.displayWidth, MC.displayHeight);
+		this.bufferSize = this.start.getWidth() * this.start.getHeight() * bytesPerPixel;
+		this.buffer = ByteBuffer.allocateDirect(this.bufferSize);
+	}
+
+	private void prepareByteBuffer() {
+		if (flipLine1 == null || flipLine2 == null) {
+			return;
+		}
+
+		final int currentWidth = start.getWidth();
+		final int currentHeight = start.getHeight();
+
+		// flip buffer vertically
+		for (int i = 0; i < currentHeight / 2; i++) {
+			final int ofs1 = i * currentWidth * bytesPerPixel;
+			final int ofs2 = (currentHeight - i - 1) * currentWidth * bytesPerPixel;
+
+			// read lines
+			this.buffer.position(ofs1);
+			this.buffer.get(this.flipLine1);
+			this.buffer.position(ofs2);
+			this.buffer.get(this.flipLine2);
+
+			// write lines at swapped positions
+			this.buffer.position(ofs2);
+			this.buffer.put(this.flipLine1);
+			this.buffer.position(ofs1);
+			this.buffer.put(this.flipLine2);
+		}
+	}
+
+	public final void setFlipColors() {
+		colorFormat = GL_BGR;
+	}
+
+	public final void setFlipLines() {
+		flipLine1 = new byte[start.getWidth() * bytesPerPixel];
+		flipLine2 = new byte[start.getWidth() * bytesPerPixel];
+	}
+
+	public final ByteBuffer getByteBuffer() {
+		prepareByteBuffer();
+		// Rewinding to pos 0 (after capture)
+		this.buffer.rewind();
+		// ByteBuffer was once duplicated right here -> resulting in heavy
+		// memory allocation (eg. 1280*720*3 bytes, which is about 2.8 MB per
+		// frame and about 1.7 GB for 10 seconds in 60fps)
+		// I know that this is not good practice, but it does not matter and
+		// optimizes a lot
+		return buffer;
+	}
+
+	public final void doCapture() {
+		final int currentWidth = MC.displayWidth;
+		final int currentHeight = MC.displayHeight;
+		// check if the dimensions are still the same
+		if (currentWidth != start.getWidth() || currentHeight != start.getHeight()) {
+			throw new IllegalStateException(
+					String.format("Display size changed! %dx%d not equals the start dimension of %dx%d", currentWidth,
+							currentHeight, start.getWidth(), start.getHeight()));
+		}
+
+		// Rewind after writting
+		this.buffer.rewind();
+		capture();
+	}
+
+	public final Dimension getCaptureDimension() {
+		return this.start;
+	}
+
+	protected abstract void capture();
+
+	public abstract void close();
+
+}

--- a/src/main/java/info/ata4/minecraft/minema/client/capture/FramebufferCapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/FramebufferCapturer.java
@@ -17,7 +17,6 @@ import static org.lwjgl.opengl.GL11.glGetTexImage;
 import static org.lwjgl.opengl.GL11.glPixelStorei;
 import static org.lwjgl.opengl.GL11.glReadPixels;
 
-import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.shader.Framebuffer;
 
 /**
@@ -34,7 +33,7 @@ public class FramebufferCapturer extends ACapturer {
 
 		// read texture from framebuffer if enabled, otherwise use slower
 		// glReadPixels
-		if (OpenGlHelper.isFramebufferEnabled()) {
+		if (isFramebufferEnabled) {
 			final Framebuffer fb = MC.getFramebuffer();
 			glBindTexture(GL_TEXTURE_2D, fb.framebufferTexture);
 			glGetTexImage(GL_TEXTURE_2D, 0, colorFormat, TYPE, this.buffer);

--- a/src/main/java/info/ata4/minecraft/minema/client/capture/FramebufferCapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/FramebufferCapturer.java
@@ -10,21 +10,13 @@
 package info.ata4.minecraft.minema.client.capture;
 
 import static org.lwjgl.opengl.GL11.GL_PACK_ALIGNMENT;
-import static org.lwjgl.opengl.GL11.GL_RGB;
 import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
 import static org.lwjgl.opengl.GL11.GL_UNPACK_ALIGNMENT;
-import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
 import static org.lwjgl.opengl.GL11.glBindTexture;
 import static org.lwjgl.opengl.GL11.glGetTexImage;
 import static org.lwjgl.opengl.GL11.glPixelStorei;
 import static org.lwjgl.opengl.GL11.glReadPixels;
-import static org.lwjgl.opengl.GL12.GL_BGR;
 
-import java.nio.ByteBuffer;
-
-import org.lwjgl.util.Dimension;
-
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.shader.Framebuffer;
 
@@ -32,93 +24,26 @@ import net.minecraft.client.shader.Framebuffer;
  *
  * @author Nico Bergemann <barracuda415 at yahoo.de>
  */
-public class FramebufferCapturer {
+public class FramebufferCapturer extends ACapturer {
 
-	private static final int bytesPerPixel = 3;
-	private static final int TYPE = GL_UNSIGNED_BYTE;
-	private static final Minecraft MC = Minecraft.getMinecraft();
-
-	private final ByteBuffer bb;
-	private final Dimension start;
-
-	private byte[] flipLine1 = null;
-	private byte[] flipLine2 = null;
-	private int colorFormat = GL_RGB;
-
-	public FramebufferCapturer() {
-		this.start = new Dimension(MC.displayWidth, MC.displayHeight);
-		this.bb = ByteBuffer.allocateDirect(this.start.getWidth() * this.start.getHeight() * bytesPerPixel);
-	}
-
-	public void setFlipColors() {
-		colorFormat = GL_BGR;
-	}
-
-	public void setFlipLines() {
-		flipLine1 = new byte[start.getWidth() * bytesPerPixel];
-		flipLine2 = new byte[start.getWidth() * bytesPerPixel];
-	}
-
-	public ByteBuffer getByteBuffer() {
-		// Rewinding to pos 0 (after capture)
-		this.bb.rewind();
-		// ByteBuffer was once duplicated right here -> resulting in heavy
-		// memory allocation (eg. 1280*720*3 bytes, which is about 2.8 MB per
-		// frame and about 1.7 GB for 10 seconds in 60fps)
-		// I know that this is not good practice, but it does not matter and
-		// optimizes a lot
-		return this.bb;
-	}
-
-	public Dimension getCaptureDimension() {
-		return this.start;
-	}
-
-	public void capture() {
-		// check if the dimensions are still the same
-		if (MC.displayWidth != start.getWidth() || MC.displayHeight != start.getHeight()) {
-			throw new IllegalStateException(
-					String.format("Display size changed! %dx%d not equals the start dimension of %dx%d",
-							MC.displayWidth, MC.displayHeight, start.getWidth(), start.getHeight()));
-		}
-
+	@Override
+	protected void capture() {
 		// set alignment flags
 		glPixelStorei(GL_PACK_ALIGNMENT, 1);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-		// Rewinding to pos 0 (after writting bytebuffer via FrameExporter)
-		this.bb.rewind();
 
 		// read texture from framebuffer if enabled, otherwise use slower
 		// glReadPixels
 		if (OpenGlHelper.isFramebufferEnabled()) {
 			final Framebuffer fb = MC.getFramebuffer();
 			glBindTexture(GL_TEXTURE_2D, fb.framebufferTexture);
-			glGetTexImage(GL_TEXTURE_2D, 0, colorFormat, TYPE, this.bb);
+			glGetTexImage(GL_TEXTURE_2D, 0, colorFormat, TYPE, this.buffer);
 		} else {
-			glReadPixels(0, 0, MC.displayWidth, MC.displayHeight, colorFormat, TYPE, this.bb);
+			glReadPixels(0, 0, start.getWidth(), start.getHeight(), colorFormat, TYPE, this.buffer);
 		}
+	}
 
-		if (flipLine1 == null || flipLine2 == null) {
-			return;
-		}
-
-		// flip buffer vertically
-		for (int i = 0; i < MC.displayHeight / 2; i++) {
-			final int ofs1 = i * MC.displayWidth * bytesPerPixel;
-			final int ofs2 = (MC.displayHeight - i - 1) * MC.displayWidth * bytesPerPixel;
-
-			// read lines
-			this.bb.position(ofs1);
-			this.bb.get(this.flipLine1);
-			this.bb.position(ofs2);
-			this.bb.get(this.flipLine2);
-
-			// write lines at swapped positions
-			this.bb.position(ofs2);
-			this.bb.put(this.flipLine1);
-			this.bb.position(ofs1);
-			this.bb.put(this.flipLine2);
-		}
+	@Override
+	public void close() {
 	}
 }

--- a/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
@@ -54,6 +54,7 @@ public class PBOCapturer extends ACapturer {
 		backCache = swapGlBuffer;
 	}
 
+	@Override
 	public void capture() {
 		glBindBufferARB(PACK_MODE, frontAddress);
 

--- a/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
@@ -1,0 +1,82 @@
+package info.ata4.minecraft.minema.client.capture;
+
+import static org.lwjgl.opengl.ARBBufferObject.glBindBufferARB;
+import static org.lwjgl.opengl.ARBBufferObject.glBufferDataARB;
+import static org.lwjgl.opengl.ARBBufferObject.glDeleteBuffersARB;
+import static org.lwjgl.opengl.ARBBufferObject.glGenBuffersARB;
+import static org.lwjgl.opengl.ARBBufferObject.glMapBufferARB;
+import static org.lwjgl.opengl.ARBBufferObject.glUnmapBufferARB;
+import static org.lwjgl.opengl.GL11.GL_PACK_ALIGNMENT;
+import static org.lwjgl.opengl.GL11.GL_UNPACK_ALIGNMENT;
+import static org.lwjgl.opengl.GL11.GL_UNSIGNED_BYTE;
+import static org.lwjgl.opengl.GL11.glPixelStorei;
+
+import java.nio.ByteBuffer;
+
+import org.lwjgl.opengl.ARBPixelBufferObject;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GLContext;
+
+public class PBOCapturer extends ACapturer {
+
+	public static final boolean isSupported = GLContext.getCapabilities().GL_ARB_pixel_buffer_object;
+
+	private static final int pixelPackBuffer = ARBPixelBufferObject.GL_PIXEL_PACK_BUFFER_ARB;
+	private final static int STREAM_READ = ARBPixelBufferObject.GL_STREAM_READ_ARB;
+
+	private int frontAddress;
+	private int backAddress;
+	private ByteBuffer frontCache;
+	private ByteBuffer backCache;
+
+	public PBOCapturer() {
+		this.frontAddress = glGenBuffersARB();
+		glBindBufferARB(pixelPackBuffer, frontAddress);
+		glBufferDataARB(pixelPackBuffer, bufferSize, STREAM_READ);
+
+		this.backAddress = glGenBuffersARB();
+		glBindBufferARB(pixelPackBuffer, backAddress);
+		glBufferDataARB(pixelPackBuffer, bufferSize, STREAM_READ);
+
+		glBindBufferARB(pixelPackBuffer, 0);
+	}
+
+	private void swapPBOs() {
+		int swapAddress = this.frontAddress;
+		frontAddress = backAddress;
+		backAddress = swapAddress;
+		ByteBuffer swapGlBuffer = frontCache;
+		frontCache = backCache;
+		backCache = swapGlBuffer;
+	}
+
+	public void capture() {
+		// set alignment flags
+		glPixelStorei(GL_PACK_ALIGNMENT, 1);
+		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+		glBindBufferARB(pixelPackBuffer, frontAddress);
+
+		GL11.glReadPixels(0, 0, start.getWidth(), start.getHeight(), colorFormat, GL_UNSIGNED_BYTE, 0);
+
+		glBindBufferARB(pixelPackBuffer, 0);
+
+		swapPBOs();
+
+		glBindBufferARB(pixelPackBuffer, frontAddress);
+
+		frontCache = glMapBufferARB(pixelPackBuffer, STREAM_READ, bufferSize, frontCache);
+		if (frontCache != null) // Is null for the first frame
+			this.buffer.put(frontCache);
+		glUnmapBufferARB(pixelPackBuffer);
+
+		glBindBufferARB(pixelPackBuffer, 0);
+	}
+
+	@Override
+	public void close() {
+		glDeleteBuffersARB(frontAddress);
+		glDeleteBuffersARB(backAddress);
+	}
+
+}

--- a/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
@@ -18,7 +18,6 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GLContext;
 import org.lwjgl.opengl.Util;
 
-import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.shader.Framebuffer;
 
 public class PBOCapturer extends ACapturer {
@@ -60,12 +59,12 @@ public class PBOCapturer extends ACapturer {
 
 		// Calling into event queue
 
-		// set alignment flags
+		// set alignment flags (has to be inside event queue)
 		glPixelStorei(GL_PACK_ALIGNMENT, 1);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
 		// use faster framebuffer access if enabled
-		if (OpenGlHelper.isFramebufferEnabled()) {
+		if (isFramebufferEnabled) {
 			Framebuffer buffer = MC.getFramebuffer();
 			buffer.bindFramebufferTexture();
 			GL11.glGetTexImage(GL11.GL_TEXTURE_2D, 0, colorFormat, GL_UNSIGNED_BYTE, 0L);

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
@@ -19,7 +19,9 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import info.ata4.minecraft.minema.client.capture.ACapturer;
 import info.ata4.minecraft.minema.client.capture.FramebufferCapturer;
+import info.ata4.minecraft.minema.client.capture.PBOCapturer;
 import info.ata4.minecraft.minema.client.config.MinemaConfig;
 import info.ata4.minecraft.minema.client.event.FrameCaptureEvent;
 import info.ata4.minecraft.minema.client.event.FramePreCaptureEvent;
@@ -43,7 +45,7 @@ public class CaptureSession extends ACaptureModule {
 	private final EventBus eventBus = new EventBus();
 
 	private CaptureTime time;
-	private FramebufferCapturer fbc;
+	private ACapturer capturer;
 
 	private File movieDir;
 
@@ -97,12 +99,19 @@ public class CaptureSession extends ACaptureModule {
 		this.time = new CaptureTime(this.cfg);
 
 		// configure framebuffer capturer
-		this.fbc = new FramebufferCapturer();
-		exporter.configureCapturer(this.fbc);
+		if (PBOCapturer.isSupported) {
+			capturer = new PBOCapturer();
+			System.out.println("Using PBO: true");
+		} else {
+			capturer = new FramebufferCapturer();
+			System.out.println("Using PBO: true");
+		}
+		exporter.configureCapturer(this.capturer);
 	}
 
 	@Override
 	protected void doDisable() {
+		capturer.close();
 		// disable and unregister modules
 		for (final ACaptureModule module : this.modules) {
 			try {
@@ -177,14 +186,14 @@ public class CaptureSession extends ACaptureModule {
 
 		try {
 			if (this.eventBus
-					.post(new FramePreCaptureEvent(this.time.getNumFrames(), this.fbc.getCaptureDimension()))) {
+					.post(new FramePreCaptureEvent(this.time.getNumFrames(), this.capturer.getCaptureDimension()))) {
 				throw new RuntimeException("Frame capturing cancelled at frame " + this.time.getNumFrames());
 			}
 
-			this.fbc.capture();
+			this.capturer.doCapture();
 
-			if (this.eventBus.post(new FrameCaptureEvent(this.time.getNumFrames(), this.fbc.getCaptureDimension(),
-					this.fbc.getByteBuffer()))) {
+			if (this.eventBus.post(new FrameCaptureEvent(this.time.getNumFrames(), this.capturer.getCaptureDimension(),
+					this.capturer.getByteBuffer()))) {
 				throw new RuntimeException("Frame capturing cancelled at frame " + this.time.getNumFrames());
 			}
 

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
@@ -104,7 +104,7 @@ public class CaptureSession extends ACaptureModule {
 			System.out.println("Using PBO: true");
 		} else {
 			capturer = new FramebufferCapturer();
-			System.out.println("Using PBO: true");
+			System.out.println("Using PBO: false");
 		}
 		exporter.configureCapturer(this.capturer);
 	}

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/FrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/FrameExporter.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import info.ata4.minecraft.minema.client.capture.FramebufferCapturer;
+import info.ata4.minecraft.minema.client.capture.ACapturer;
 import info.ata4.minecraft.minema.client.config.MinemaConfig;
 import info.ata4.minecraft.minema.client.event.FrameCaptureEvent;
 import info.ata4.minecraft.minema.client.event.FramePreCaptureEvent;
@@ -103,5 +103,5 @@ public abstract class FrameExporter extends ACaptureModule {
 
 	protected abstract void doExportFrame(FrameCaptureEvent evt) throws Exception;
 
-	public abstract void configureCapturer(FramebufferCapturer fbc);
+	public abstract void configureCapturer(ACapturer fbc);
 }

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/ImageFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/ImageFrameExporter.java
@@ -37,11 +37,9 @@ public class ImageFrameExporter extends FrameExporter {
 	@Override
 	public void configureCapturer(final FramebufferCapturer fbc) {
 		if (this.cfg.imageFormat.get().equals("tga")) {
-			fbc.setFlipColors(true);
-			fbc.setFlipLines(false);
+			fbc.setFlipColors();
 		} else {
-			fbc.setFlipColors(false);
-			fbc.setFlipLines(true);
+			fbc.setFlipLines();
 		}
 	}
 

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/ImageFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/ImageFrameExporter.java
@@ -37,10 +37,10 @@ public class ImageFrameExporter extends FrameExporter {
 	@Override
 	public void configureCapturer(final ACapturer fbc) {
 		if (this.cfg.imageFormat.get().equals("tga")) {
-			fbc.setFlipColors();
-		} else {
-			fbc.setFlipLines();
+			return;
 		}
+		fbc.setFlipLines();
+		fbc.setToRGBMode();
 	}
 
 	@Override

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/ImageFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/ImageFrameExporter.java
@@ -20,7 +20,7 @@ import javax.imageio.ImageIO;
 
 import org.apache.commons.io.IOUtils;
 
-import info.ata4.minecraft.minema.client.capture.FramebufferCapturer;
+import info.ata4.minecraft.minema.client.capture.ACapturer;
 import info.ata4.minecraft.minema.client.config.MinemaConfig;
 import info.ata4.minecraft.minema.client.event.FrameCaptureEvent;
 
@@ -35,7 +35,7 @@ public class ImageFrameExporter extends FrameExporter {
 	}
 
 	@Override
-	public void configureCapturer(final FramebufferCapturer fbc) {
+	public void configureCapturer(final ACapturer fbc) {
 		if (this.cfg.imageFormat.get().equals("tga")) {
 			fbc.setFlipColors();
 		} else {

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/PipeFrameExporter.java
@@ -93,8 +93,7 @@ public class PipeFrameExporter extends FrameExporter {
 
 	@Override
 	public void configureCapturer(final FramebufferCapturer fbc) {
-		fbc.setFlipColors(false);
-		fbc.setFlipLines(true);
+		fbc.setFlipLines();
 	}
 
 	@Override

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/PipeFrameExporter.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import info.ata4.minecraft.minema.client.capture.FramebufferCapturer;
+import info.ata4.minecraft.minema.client.capture.ACapturer;
 import info.ata4.minecraft.minema.client.config.MinemaConfig;
 import info.ata4.minecraft.minema.client.event.FrameCaptureEvent;
 import info.ata4.minecraft.minema.io.StreamPipe;
@@ -92,7 +92,7 @@ public class PipeFrameExporter extends FrameExporter {
 	}
 
 	@Override
-	public void configureCapturer(final FramebufferCapturer fbc) {
+	public void configureCapturer(final ACapturer fbc) {
 		fbc.setFlipLines();
 	}
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid" : "Minema",
   "name" : "Minema",
   "description": "This mod allows you to record fluid movies in Minecraft, even if the video recording itself isn't.\nThis is made possible by a temporary modification of the game timer that ensures a constant game time passed between each frame, disabling any synchronization with the actual time.\nIn other words: performance doesn't matter for fluid videos anymore!",
-  "version" : "3.2-beta.3",
+  "version" : "3.2-beta.4",
   "url" : "http://www.minecraftforum.net/topic/926293-",
   "authorList": ["Barracuda","Gregosteros"]
 }


### PR DESCRIPTION
Here I am again :)

An overview:

- Heavy memory optimization while recording:
You copied the ByteBuffer on the client memory side before giving it to the Exporter (not necessary)

- New PBOCapturer using two alternating pixel buffers for readback when supported by the GPU (Readback speed increased by about 8 times on a GTX 750 Ti)
This is a good ressource: http://www.songho.ca/opengl/gl_pbo.html

- New generalized ACapturer abstract class

- Using BGR color format for PipeExporter now, too
-> Internal OpenGL format
-> Stabilizes readback and ffmpeg handles it well
Requires new encoder arguments:
Lossy H264: "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -an -c:v libx264 -preset medium -qp 10 video.mp4"