### PR TITLE
Fix recording two images per frame/play the chicken plop again

### DIFF
--- a/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/capture/PBOCapturer.java
@@ -83,7 +83,7 @@ public class PBOCapturer extends ACapturer {
 		glBindBufferARB(PACK_MODE, frontAddress);
 
 		frontCache = glMapBufferARB(PACK_MODE, READ_ONLY_ACCESS, bufferSize, frontCache);
-		// If mapping threw an error -> crash immediatly please
+		// If mapping threw an error -> crash immediately please
 		Util.checkGLError();
 		this.buffer.put(frontCache);
 		// Recycling native buffers also needs rewinding! Not doing so would

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
@@ -27,6 +27,9 @@ import info.ata4.minecraft.minema.client.event.FrameCaptureEvent;
 import info.ata4.minecraft.minema.client.event.FramePreCaptureEvent;
 import info.ata4.minecraft.minema.client.util.CaptureTime;
 import info.ata4.minecraft.minema.client.util.ChatUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.EventBus;
@@ -40,7 +43,8 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
  */
 public class CaptureSession extends ACaptureModule {
 
-	private static final Logger L = LogManager.getLogger();
+	public static final Logger L = LogManager.getLogger();
+	public static final Minecraft MC = Minecraft.getMinecraft();
 
 	private final ArrayList<ACaptureModule> modules = new ArrayList<ACaptureModule>();
 	private final EventBus eventBus = new EventBus();
@@ -108,6 +112,8 @@ public class CaptureSession extends ACaptureModule {
 			System.out.println("Using PBO: false");
 		}
 		exporter.configureCapturer(this.capturer);
+
+		playChickenPlop();
 	}
 
 	@Override
@@ -212,6 +218,15 @@ public class CaptureSession extends ACaptureModule {
 			L.error("Frame capturing error", t);
 			handleError(t);
 			disable();
+		}
+	}
+
+	private void playChickenPlop() {
+		try {
+			MC.theWorld.playSound(MC.thePlayer, MC.thePlayer.playerLocation, SoundEvents.entity_chicken_egg,
+					SoundCategory.NEUTRAL, 1, 1);
+		} catch (final Exception e) {
+			L.error("cannot play chicken plop", e);
 		}
 	}
 

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/CaptureSession.java
@@ -31,6 +31,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.EventBus;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
 
 /**
@@ -174,6 +175,11 @@ public class CaptureSession extends ACaptureModule {
 	@SubscribeEvent
 	public void captureFrame(final RenderTickEvent e) {
 		if (!isEnabled()) {
+			return;
+		}
+		if (e.phase == Phase.START) {
+			// Only record at the end of the frame (fixes recording two images
+			// per frame)
 			return;
 		}
 

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/PipeFrameExporter.java
@@ -14,7 +14,6 @@ import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -56,7 +55,8 @@ public class PipeFrameExporter extends FrameExporter {
 
 		final List<String> cmds = new ArrayList<String>();
 		cmds.add(this.cfg.videoEncoderPath.get());
-		cmds.addAll(Arrays.asList(StringUtils.split(params, ' ')));
+		for (String s : StringUtils.split(params, ' '))
+			cmds.add(s);
 
 		// build encoder process
 		final ProcessBuilder pb = new ProcessBuilder(cmds);

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid" : "Minema",
   "name" : "Minema",
   "description": "This mod allows you to record fluid movies in Minecraft, even if the video recording itself isn't.\nThis is made possible by a temporary modification of the game timer that ensures a constant game time passed between each frame, disabling any synchronization with the actual time.\nIn other words: performance doesn't matter for fluid videos anymore!",
-  "version" : "3.2-beta.4",
+  "version" : "3.2-beta.5",
   "url" : "http://www.minecraftforum.net/topic/926293-",
   "authorList": ["Barracuda","Gregosteros"]
 }


### PR DESCRIPTION
So, I fixed the issue with recording two identical images.
The issue was that the RenderTickEvent has two Phases: Phase#END and Phase#START
Every call with Phase#START is now skipped

Secondly, minema will now play the chicken plop again.

This will be my last pull request until you can push your own code format again. I do not want you to be bothered too much with my code formatting. (see the last comment on my second pull request)
